### PR TITLE
ignore the error on the RouteMessage on Darwin

### DIFF
--- a/netroute_bsd.go
+++ b/netroute_bsd.go
@@ -9,7 +9,7 @@
 
 // This is a BSD import for the routing structure initially found in
 // https://github.com/google/gopacket/blob/master/routing/routing.go
-//RIB parsing follows the BSD route format described in
+// RIB parsing follows the BSD route format described in
 // https://github.com/freebsd/freebsd/blob/master/sys/net/route.h
 package netroute
 
@@ -67,6 +67,8 @@ func New() (routing.Router, error) {
 	var ipn *net.IPNet
 	for _, msg := range msgs {
 		m := msg.(*route.RouteMessage)
+		// We ignore the error (m.Err) here. It's not clear what this error actually means,
+		// and it makes us miss routes that _should_ be included.
 		routeInfo := new(rtInfo)
 
 		if m.Version < 3 || m.Version > 5 {
@@ -78,9 +80,6 @@ func New() (routing.Router, error) {
 
 		if m.Flags&RTF_UP == 0 ||
 			m.Flags&(RTF_REJECT|RTF_BLACKHOLE) != 0 {
-			continue
-		}
-		if m.Err != nil {
 			continue
 		}
 


### PR DESCRIPTION
On OSX we're seeing that routes are missing. For example, when asking for a route to 127.0.0.1, this package wouldn't give us a 127.0.0.1 source, but some other address, e.g. a 192.168. address.

The reason seems to be that a lot of the `route.RouteMessage`s on OSX have the `Err` field set, and we therefore ignore them: https://github.com/libp2p/go-netroute/blob/64e978a241fa9f86b68a21e228ac66a76b28cc38/netroute_bsd.go#L83-L85

For example, these are the v4 routes that are currently returned on my system (IPs blanked for privacy):
```
v4 routes (total: 52):
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 0.0.0.0/1, err: <nil> }
{ interface: 0, src: 192.168.1.112/0, dst: 0.0.0.0/0, err: <nil> }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 10.64.0.1/32, err: errno 4553 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 13.248.xxx.xxx/32, err: errno 713 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 17.57.xxx.xxx/32, err: too many levels of remote in path }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 17.248.xxx.xxx/32, err: operation not supported by device }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 17.253.xxx.xxx/32, err: operation not permitted }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 17.253.xxx.xxx/32, err: operation not permitted }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 17.253.xxx.xxx/32, err: operation not permitted }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 18.132.xxx.xxx/32, err: errno 318 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 18.197.xxx.xxx/32, err: errno 10209 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 18.204.xxx.xxx/32, err: file too large }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 18.204.xxx.xxx/32, err: errno 1372 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 35.185.xxx.xxx/32, err: errno 171 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 35.186.xxx.xxx/32, err: errno 7544 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 35.186.xxx.xxx/32, err: errno 661 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 35.190.xxx.xxx/32, err: errno 380 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 40.115.xxx.xxx/32, err: not a directory }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 44.238.xxx.xxx/32, err: errno 134 }
{ interface: 0, src: 127.0.0.1/32, dst: 127.0.0.0/8, err: errno 117 }
{ interface: 0, src: 127.0.0.1/32, dst: 127.0.0.1/32, err: errno 15068594 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 128.0.0.0/1, err: <nil> }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 138.91.xxx.xxx/32, err: text file busy }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 140.82.xxx.xxx/32, err: errno 174 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 140.82.xxx.xxx/32, err: errno 1971 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 140.82.xxx.xxx/32, err: broken pipe }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 142.250.xxx.xxx/32, err: errno 517 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 142.250.xxx.xxx/32, err: errno 224 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 142.250.xxx.xxx/32, err: errno 4218 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 142.250.xxx.xxx/32, err: errno 533 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 142.251.xxx.xxx/32, err: errno 913 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 142.251.xxx.xxx/32, err: not a STREAM }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 142.251.xxx.xxx/32, err: errno 3922 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 157.240.xxx.xxx/32, err: errno 511 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 157.240.xxx.xxx/32, err: errno 450 }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 157.240.xxx.xxx/32, err: errno 4296 }
{ interface: 0, src: 192.168.1.112/32, dst: 169.254.xxx.xxx/16, err: <nil> }
{ interface: 0, src: 192.168.1.112/0, dst: 185.213.xxx.xxx/32, err: <nil> }
{ interface: 0, src: 192.168.1.112/0, dst: 185.213.xxx.xxx/32, err: errno 619487 }
{ interface: 0, src: 192.168.1.112/32, dst: 192.168.1.0/24, err: <nil> }
{ interface: 0, src: 192.168.1.112/32, dst: 192.168.1.1/32, err: <nil> }
{ interface: 0, src: 192.168.1.112/32, dst: 192.168.1.1/32, err: <nil> }
{ interface: 0, src: 192.168.1.112/32, dst: 192.168.1.112/32, err: <nil> }
{ interface: 0, src: 192.168.1.112/32, dst: 192.168.1.145/32, err: <nil> }
{ interface: 0, src: 192.168.1.112/32, dst: 192.168.1.154/32, err: <nil> }
{ interface: 0, src: 192.168.1.112/32, dst: 192.168.1.255/32, err: errno 317 }
{ interface: 0, src: 192.168.1.112/0, dst: 194.36.xxx.xxx/32, err: <nil> }
{ interface: 0, src: 10.107.xxx.xxx/32, dst: 217.138.xxx.xxx/32, err: block device required }
{ interface: 0, src: 192.168.1.112/32, dst: 224.0.xxx.xxx/4, err: <nil> }
{ interface: 0, src: 192.168.1.112/32, dst: 224.0.xxx.xxx/32, err: can't send after socket shutdown }
{ interface: 0, src: 192.168.1.112/32, dst: 239.255.xxx.xxx/32, err: errno 612 }
{ interface: 0, src: 192.168.1.112/32, dst: 255.255.xxx.xxx/32, err: <nil> }
```
All routes with a non-`nil` error would be ignored by our current code.

For reference, this is the output of `netstat -rna -f inet`:
```
Routing tables

Internet:
Destination        Gateway            Flags           Netif Expire
0/1                utun3              UScg            utun3
default            192.168.1.1        UGScg             en0
10.64.0.1              utun3              UHWIig          utun3
13.69.xxx.xxx      utun3              UHWIig          utun3
13.248.xxx.xxx    utun3              UHWIig          utun3
17.57.xxx.xxx        utun3              UHWIig          utun3
17.248.xxx.xxx     utun3              UHW3Ig          utun3      7
18.132.xxx.xxx     utun3              UHWIig          utun3
18.197.xxx.xxx      utun3              UHWIig          utun3
18.204.xxx.xxx     utun3              UHWIig          utun3
18.204.xxx.xxx      utun3              UHWIig          utun3
35.185.xxx.xxx      utun3              UHWIig          utun3
35.186.xxx.xxx      utun3              UHWIig          utun3
35.186.xxx.xxx      utun3              UHWIig          utun3
35.190.xxx.xxx       utun3              UHWIig          utun3
44.238.xxx.xxx      utun3              UHWIig          utun3
127                127.0.0.1          UCS               lo0
127.0.0.1          127.0.0.1          UH                lo0
128.0/1            utun3              USc             utun3
140.82.xxx.xxx      utun3              UHWIi           utun3
140.82.xxx.xxx      utun3              UHWIi           utun3
140.82.xxx.xxx      utun3              UHWIi           utun3
142.250.xxx.xxx    utun3              UHWIi           utun3
142.250.xxx.xxx    utun3              UHWIi           utun3
142.250.xxx.xxx    utun3              UHWIi           utun3
142.250.xxx.xxx    utun3              UHWIi           utun3
142.250.xxx.xxx    utun3              UHW3I           utun3      3
142.251.xxx.xxx    utun3              UHW3I           utun3      !
142.251.xxx.xxx    utun3              UHWIi           utun3
157.240.xxx.xxx    utun3              UHWIi           utun3
157.240.xxx.xxx    utun3              UHWIi           utun3
157.240.xxx.xxx    utun3              UHWIi           utun3
169.254            link#14            UCS               en0      !
185.213.xxx.xxx/32 192.168.1.1        UGSc              en0
185.213.xxx.xxx    192.168.1.1        UGHWIi            en0
192.168.1          link#14            UCS               en0      !
192.168.1.1/32     link#14            UCS               en0      !
192.168.1.1        e8:9f:80:f5:7a:48  UHLWIi            en0   1196
192.168.1.112/32   link#14            UCS               en0      !
192.168.1.145      7a:72:5c:1d:e3:d0  UHLWI             en0      !
192.168.1.154      a2:11:97:de:a0:a6  UHLWI             en0      !
192.168.1.255      ff:ff:ff:ff:ff:ff  UHLWbI            en0      !
194.36.xxx.xxx/32    192.168.1.1        UGSc              en0
224.0.0/4          link#14            UmCS              en0      !
224.0.0.251        1:0:5e:0:0:fb      UHmLWI            en0
239.255.xxx.xxx    1:0:5e:7f:ff:fa    UHmLWI            en0
255.255.255.255/32 link#14            UCS               en0      !
```

Note that the number of routes is _roughly_ the same (the exact number fluctuates from minute to minute), which might be an indication that ignoring the error would be the right thing to do.
