### PR TITLE
move some functions from go-sockaddr here, remove go-sockaddr dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/google/gopacket v1.1.19
-	github.com/libp2p/go-sockaddr v0.1.1
 	golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6
 	golang.org/x/sys v0.0.0-20210426080607-c94f62235c83
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
-github.com/libp2p/go-sockaddr v0.1.1 h1:yD80l2ZOdGksnOyHrhxDdTDFrf7Oy+v3FMVArIRgZxQ=
-github.com/libp2p/go-sockaddr v0.1.1/go.mod h1:syPvOmNs24S3dFVGJA1/mrqdeijPxLV2Le3BRLKd68k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
@@ -12,7 +10,6 @@ golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6 h1:0PC75Fz/kyMGhL0e1QnypqK2k
 golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/netroute_windows.go
+++ b/netroute_windows.go
@@ -15,8 +15,6 @@ import (
 	"unsafe"
 
 	"github.com/google/gopacket/routing"
-	sockaddrconv "github.com/libp2p/go-sockaddr"
-	sockaddrnet "github.com/libp2p/go-sockaddr/net"
 	"golang.org/x/sys/windows"
 )
 
@@ -54,8 +52,8 @@ type mib_row2 struct {
 }
 
 func callBestRoute(source, dest net.IP) (*mib_row2, net.IP, error) {
-	sourceAddr, _, _ := sockaddrconv.SockaddrToAny(sockaddrnet.IPAndZoneToSockaddr(source, ""))
-	destAddr, _, _ := sockaddrconv.SockaddrToAny(sockaddrnet.IPAndZoneToSockaddr(dest, ""))
+	sourceAddr, _, _ := sockaddrToAny(ipAndZoneToSockaddr(source, ""))
+	destAddr, _, _ := sockaddrToAny(ipAndZoneToSockaddr(dest, ""))
 	bestRoute := make([]byte, 512)
 	bestSource := make([]byte, 116)
 
@@ -81,7 +79,7 @@ func callBestRoute(source, dest net.IP) (*mib_row2, net.IP, error) {
 	copyInto(bestSourceRaw.Addr.Data[:], bestSource[2:16])
 	copyInto(bestSourceRaw.Pad[:], bestSource[16:])
 	addr, _ := bestSourceRaw.Sockaddr()
-	bestSrc, _ := sockaddrnet.SockaddrToIPAndZone(addr)
+	bestSrc, _ := sockaddrToIPAndZone(addr)
 
 	return route, bestSrc, nil
 }
@@ -228,7 +226,7 @@ func (r *winRouter) RouteWithSrc(input net.HardwareAddr, src, dst net.IP) (iface
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	nextHop, _ := sockaddrnet.SockaddrToIPAndZone(addr)
+	nextHop, _ := sockaddrToIPAndZone(addr)
 
 	return iface, nextHop, pref, nil
 }

--- a/sockaddr_windows.go
+++ b/sockaddr_windows.go
@@ -1,0 +1,131 @@
+//go:build windows
+// +build windows
+
+package netroute
+
+import (
+	"net"
+	"strconv"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// socklen is a type for the length of a sockaddr.
+type socklen uint
+
+// ipAndZoneToSockaddr converts a net.IP (with optional IPv6 Zone) to a Sockaddr
+// Returns nil if conversion fails.
+func ipAndZoneToSockaddr(ip net.IP, zone string) windows.Sockaddr {
+	// Unspecified?
+	if ip == nil {
+		if zone != "" {
+			return &windows.SockaddrInet6{ZoneId: uint32(ip6ZoneToInt(zone))}
+		}
+		return new(windows.SockaddrInet4)
+	}
+
+	// Valid IPv4?
+	if ip4 := ip.To4(); ip4 != nil && zone == "" {
+		var buf [4]byte
+		copy(buf[:], ip4) // last 4 bytes
+		return &windows.SockaddrInet4{Addr: buf}
+	}
+
+	// Valid IPv6 address?
+	if ip6 := ip.To16(); ip6 != nil {
+		var buf [16]byte
+		copy(buf[:], ip6)
+		return &windows.SockaddrInet6{Addr: buf, ZoneId: uint32(ip6ZoneToInt(zone))}
+	}
+
+	return nil
+}
+
+// sockaddrToIPAndZone converts a Sockaddr to a net.IP (with optional IPv6 Zone)
+// Returns nil if conversion fails.
+func sockaddrToIPAndZone(sa windows.Sockaddr) (net.IP, string) {
+	switch sa := sa.(type) {
+	case *windows.SockaddrInet4:
+		ip := make([]byte, 16)
+		// V4InV6Prefix
+		ip[10] = 0xff
+		ip[11] = 0xff
+		copy(ip[12:16], sa.Addr[:])
+		return ip, ""
+	case *windows.SockaddrInet6:
+		ip := make([]byte, 16)
+		copy(ip, sa.Addr[:])
+		return ip, ip6ZoneToString(int(sa.ZoneId))
+	}
+	return nil, ""
+}
+
+func sockaddrToAny(sa windows.Sockaddr) (*windows.RawSockaddrAny, socklen, error) {
+	if sa == nil {
+		return nil, 0, syscall.EINVAL
+	}
+
+	switch sa := sa.(type) {
+	case *windows.SockaddrInet4:
+		if sa.Port < 0 || sa.Port > 0xFFFF {
+			return nil, 0, syscall.EINVAL
+		}
+		raw := new(windows.RawSockaddrAny)
+		raw.Addr.Family = windows.AF_INET
+		raw4 := (*windows.RawSockaddrInet4)(unsafe.Pointer(raw))
+		p := (*[2]byte)(unsafe.Pointer(&raw4.Port))
+		p[0] = byte(sa.Port >> 8)
+		p[1] = byte(sa.Port)
+		for i := 0; i < len(sa.Addr); i++ {
+			raw4.Addr[i] = sa.Addr[i]
+		}
+		return raw, socklen(unsafe.Sizeof(*raw4)), nil
+	case *windows.SockaddrInet6:
+		if sa.Port < 0 || sa.Port > 0xFFFF {
+			return nil, 0, syscall.EINVAL
+		}
+		raw := new(windows.RawSockaddrAny)
+		raw.Addr.Family = windows.AF_INET6
+		raw6 := (*windows.RawSockaddrInet6)(unsafe.Pointer(raw))
+		p := (*[2]byte)(unsafe.Pointer(&raw6.Port))
+		p[0] = byte(sa.Port >> 8)
+		p[1] = byte(sa.Port)
+		raw6.Scope_id = sa.ZoneId
+		for i := 0; i < len(sa.Addr); i++ {
+			raw6.Addr[i] = sa.Addr[i]
+		}
+		return raw, socklen(unsafe.Sizeof(*raw6)), nil
+	case *windows.SockaddrUnix:
+		return nil, 0, syscall.EWINDOWS
+	}
+	return nil, 0, syscall.EAFNOSUPPORT
+}
+
+// from: go/src/pkg/net/ipsock.go
+
+// ip6ZoneToString converts an IP6 Zone unix int to a net string
+// returns "" if zone is 0
+func ip6ZoneToString(zone int) string {
+	if zone == 0 {
+		return ""
+	}
+	if ifi, err := net.InterfaceByIndex(zone); err == nil {
+		return ifi.Name
+	}
+	return strconv.Itoa(zone)
+}
+
+// ip6ZoneToInt converts an IP6 Zone net string to a unix int
+// returns 0 if zone is ""
+func ip6ZoneToInt(zone string) int {
+	if zone == "" {
+		return 0
+	}
+	if ifi, err := net.InterfaceByName(zone); err == nil {
+		return ifi.Index
+	}
+	n, _ := strconv.ParseInt(zone, 10, 32)
+	return int(n)
+}


### PR DESCRIPTION
As far as I can tell, go-netroute is the only package in our stack using go-sockaddr, and it's only doing so for a few function calls on Windows.

If we move these functions (less than 150 LOC) here, we can deprecate go-sockaddr, moving us one tiny step forward in our repo consolidation effort.

Also replace `itod` and `dtoi` (https://github.com/libp2p/go-sockaddr/blob/5fafa0f91376612e1e57921afe72602c9b8b3431/net/net.go#L316-L350) with their standard library equivalents.