### PR TITLE
Stricter filtering of degenerate routes

### DIFF
--- a/common.go
+++ b/common.go
@@ -46,6 +46,11 @@ func (rt rtInfo) IsMoreSpecThan(mostSpecificRt *rtInfo) bool {
 		return false
 	}
 
+	// if all else is equal, prefer a route with a gateway.
+	if mostSpecificRt.Priority == rt.Priority && rt.Gateway == nil && mostSpecificRt.Gateway != nil {
+		return false
+	}
+
 	// Windows and MacOS hasn't metric/priority on rule entry,
 	// But the interface device has the priority property.
 	//

--- a/netroute_linux.go
+++ b/netroute_linux.go
@@ -60,12 +60,7 @@ loop:
 			if err != nil {
 				return nil, err
 			}
-			switch rt.Family {
-			case syscall.AF_INET:
-				rtr.v4 = append(rtr.v4, &routeInfo)
-			case syscall.AF_INET6:
-				rtr.v6 = append(rtr.v6, &routeInfo)
-			default:
+			if rt.Family != syscall.AF_INET && rt.Family != syscall.AF_INET6 {
 				continue loop
 			}
 			for _, attr := range attrs {
@@ -91,6 +86,18 @@ loop:
 				case syscall.RTA_PRIORITY:
 					routeInfo.Priority = *(*uint32)(unsafe.Pointer(&attr.Value[0]))
 				}
+			}
+			if routeInfo.Dst == nil && routeInfo.Src == nil && routeInfo.Gateway == nil {
+				continue loop
+			}
+			switch rt.Family {
+			case syscall.AF_INET:
+				rtr.v4 = append(rtr.v4, &routeInfo)
+			case syscall.AF_INET6:
+				rtr.v6 = append(rtr.v6, &routeInfo)
+			default:
+				// should not happen.
+				continue loop
 			}
 		}
 	}


### PR DESCRIPTION
fix #32

This chooses not to append routes that don't have source or destination when getting routes from linux It also down-weights selection of routes without gateway when all else is equal, which can be useful for choosing an underlying interface rather than a bridge interface when both are present.