### PR TITLE
Improve performance on Linux with many network interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	github.com/google/gopacket v1.1.19
 	github.com/stretchr/testify v1.10.0
+	github.com/wjordan/netinterfaces v0.1.0
 	golang.org/x/net v0.37.0
 	golang.org/x/sys v0.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/wjordan/netinterfaces v0.1.0 h1:gLOZRrOc61SsSMmJ0c660bCxA/ZoRT6HBHOYlFyLHyE=
+github.com/wjordan/netinterfaces v0.1.0/go.mod h1:Km4e70ZSru7NvdOMl4rqLjGQ2L0kQcBcEtmxZcVoHbI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=

--- a/netroute_linux.go
+++ b/netroute_linux.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/google/gopacket/routing"
+	. "github.com/wjordan/netinterfaces"
 )
 
 func New() (routing.Router, error) {
@@ -87,12 +88,12 @@ loop:
 	}
 	sort.Sort(rtr.v4)
 	sort.Sort(rtr.v6)
-	ifaces, err := net.Interfaces()
+	ifaces, err := NetInterfaces()
 	if err != nil {
 		return nil, err
 	}
 	for _, iface := range ifaces {
-		rtr.ifaces[iface.Index] = iface
+		rtr.ifaces[iface.Index] = iface.Interface
 		var addrs ipAddrs
 		ifaceAddrs, err := iface.Addrs()
 		if err != nil {

--- a/netroute_test.go
+++ b/netroute_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func BenchmarkNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := New()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestRoute(t *testing.T) {
 	r, err := New()
 	if err != nil {


### PR DESCRIPTION
The existing implementation of `New()` has a performance issue on Linux for the case when there are a large number (~ thousands) of  network interfaces on the system.

Calling `Addrs()` on a `net.Interface` triggers a netlink request (`RTM_GETADDR`) that dumps addresses for all network interfaces, then filters the response messages to the ones matching the specified interface. When `iface.Addrs()` is separately called on every item returned by `net.Interfaces()`, this results in O(n<sup>2</sup>) data being sent through netlink, and can cause significant performance issues on systems managing thousands of network interfaces (virtual TAP devices, in my case).

The fix is to collect all network addresses through a single netlink call, and assign the addresses to each network interface by index. I've created a simple drop-in module at [github.com/wjordan/netinterfaces](https://github.com/wjordan/netinterfaces) to help apply the fix with minimal diff to the existing codebase (see the [implementation here](https://github.com/wjordan/netinterfaces/blob/main/net_linux.go)).

I've included a simple benchmark test against the `New()` function, and compared the results before/after this PR on a single production host (with 1329 network interfaces):

<details><summary>before (~8255m ns/op)</summary>
<pre>
goos: linux
goarch: amd64
pkg: github.com/libp2p/go-netroute
cpu: AMD EPYC 7502P 32-Core Processor               
BenchmarkNew-64    	       1	8142832032 ns/op
BenchmarkNew-64    	       1	7926576416 ns/op
BenchmarkNew-64    	       1	8625423001 ns/op
BenchmarkNew-64    	       1	7759228885 ns/op
BenchmarkNew-64    	       1	8347337935 ns/op
BenchmarkNew-64    	       1	8783752409 ns/op
BenchmarkNew-64    	       1	8592556706 ns/op
BenchmarkNew-64    	       1	8162635159 ns/op
BenchmarkNew-64    	       1	7887760609 ns/op
BenchmarkNew-64    	       1	8525044047 ns/op
PASS
</pre>
</details>
<details><summary>after (~141m ns/op)</summary>
<pre>
goos: linux
goarch: amd64
pkg: github.com/libp2p/go-netroute
cpu: AMD EPYC 7502P 32-Core Processor               
BenchmarkNew-64    	       8	 131353497 ns/op
BenchmarkNew-64    	       8	 146446498 ns/op
BenchmarkNew-64    	       8	 161298688 ns/op
BenchmarkNew-64    	       8	 135098898 ns/op
BenchmarkNew-64    	       8	 133536285 ns/op
BenchmarkNew-64    	       7	 169874107 ns/op
BenchmarkNew-64    	       8	 145653096 ns/op
BenchmarkNew-64    	       8	 137948240 ns/op
BenchmarkNew-64    	       8	 132781627 ns/op
BenchmarkNew-64    	       8	 184450081 ns/op
PASS
</pre></details>

<details><summary>-98.28%</summary>
<pre>
$ benchstat go-netroute-master.txt go-netroute-perf_fix.txt
goos: linux
goarch: amd64
pkg: github.com/libp2p/go-netroute
cpu: AMD EPYC 7502P 32-Core Processor               
       │ go-netroute-master.txt │       go-netroute-perf_fix.txt       │
       │         sec/op         │    sec/op     vs base                │
New-64             8255.0m ± 4%   141.8m ± 20%  -98.28% (p=0.000 n=10)
</pre></details>